### PR TITLE
Remove options besides python target

### DIFF
--- a/src/components/Output.js
+++ b/src/components/Output.js
@@ -121,7 +121,7 @@ class Output extends Component<Props, State> {
                   checked={this.state.showPython}
                   onChange={this.handleChange('showPython')}
                   value="showPython"
-                  color="flat"
+                  color="default"
                 />
               }
               label="Python"

--- a/src/components/Output.js
+++ b/src/components/Output.js
@@ -15,7 +15,11 @@ import 'brace/mode/python';
 import 'brace/theme/chrome';
 
 import errorMarker from '../utils/highlighter';
-import { aceStyleProps, outputHeaderColor } from '../constants';
+import {
+  aceStyleProps,
+  outputHeaderColor,
+  headerTextStyle,
+} from '../constants';
 
 const styles = () => ({
   output: {
@@ -26,12 +30,9 @@ const styles = () => ({
     },
   },
   label: {
-    fontSize: 16,
-    textTransform: 'uppercase',
+    ...headerTextStyle,
   },
   headerSwitch: {
-    right: 0,
-    position: 'absolute',
     float: 'right',
     cursor: 'pointer',
   },
@@ -41,13 +42,15 @@ const styles = () => ({
   },
   toolbarRoot: {
     minHeight: 48,
+    padding: '0 24px',
   },
   appBar: {
     backgroundColor: outputHeaderColor,
+    boxShadow: 'none',
   },
   headerText: {
-    fontSize: 16,
-    textTransform: 'uppercase',
+    flex: 1,
+    ...headerTextStyle,
   },
 });
 

--- a/src/components/PersistentDrawer.js
+++ b/src/components/PersistentDrawer.js
@@ -14,7 +14,7 @@ import IconButton from 'material-ui/IconButton';
 import GearIcon from 'material-ui-icons/Settings';
 import ChevronLeftIcon from 'material-ui-icons/ChevronLeft';
 
-import { editorHeaderColor } from '../constants';
+import { editorHeaderColor, headerTextStyle } from '../constants';
 
 const drawerWidth = 240;
 
@@ -23,9 +23,8 @@ const styles = theme => ({
     flexGrow: 1,
   },
   headerText: {
-    textTransform: 'uppercase',
-    fontSize: 16,
     flex: 1,
+    ...headerTextStyle,
   },
   appFrame: {
     zIndex: 1,
@@ -41,6 +40,7 @@ const styles = theme => ({
       easing: theme.transitions.easing.sharp,
       duration: theme.transitions.duration.leavingScreen,
     }),
+    boxShadow: 'none',
   },
   appBarShift: {
     width: `calc(100% - ${drawerWidth}px)`,
@@ -53,7 +53,7 @@ const styles = theme => ({
     marginLeft: drawerWidth,
   },
   menuButton: {
-    marginLeft: 12,
+    marginLeft: -12,
     marginRight: 20,
   },
   hide: {
@@ -95,12 +95,11 @@ const styles = theme => ({
     marginLeft: 0,
   },
   runButton: {
-    fontSize: 15,
-    right: 0,
-    position: 'absolute',
+    ...headerTextStyle,
   },
   toolbarRoot: {
     minHeight: 48,
+    padding: '0 24px',
   },
   gearIcon: {
     fontSize: 21,

--- a/src/components/PersistentDrawer.js
+++ b/src/components/PersistentDrawer.js
@@ -108,21 +108,21 @@ const styles = theme => ({
 });
 
 const optionKeyLabels = {
-  target: 'Allowable Targets',
+  target: 'Target Python version',
 };
 
 const optionKeys = ['target'];
 
 const options = {
   target: [
-    'Allowable Targets',
+    'target',
     'Current latest version (Default)',
-    'Python >= 2.6',
-    'Python >= 2.7',
-    'Python >= 3.2',
-    'Python >= 3.3',
-    'Python >= 3.5',
-    'Python >= 3.6',
+    'Python 2.6',
+    'Python 2.7',
+    'Python 3.2',
+    'Python 3.3',
+    'Python 3.5',
+    'Python 3.6',
   ],
 };
 

--- a/src/components/PersistentDrawer.js
+++ b/src/components/PersistentDrawer.js
@@ -13,6 +13,7 @@ import Divider from 'material-ui/Divider';
 import IconButton from 'material-ui/IconButton';
 import GearIcon from 'material-ui-icons/Settings';
 import ChevronLeftIcon from 'material-ui-icons/ChevronLeft';
+import PlayArrow from 'material-ui-icons/PlayArrow';
 
 import { editorHeaderColor, headerTextStyle } from '../constants';
 
@@ -299,6 +300,7 @@ class PersistentDrawer extends React.Component {
                 disabled={this.props.loading}
               >
                 Run
+                <PlayArrow />
               </Button>
             </Toolbar>
           </AppBar>

--- a/src/components/PersistentDrawer.js
+++ b/src/components/PersistentDrawer.js
@@ -216,6 +216,7 @@ class PersistentDrawer extends React.Component {
           <List component="nav">
             {optionKeys.map(option => (
               <ListItem
+                key={option}
                 button
                 aria-haspopup="true"
                 aria-controls={option}
@@ -231,6 +232,7 @@ class PersistentDrawer extends React.Component {
           </List>
           {optionKeys.map(option => (
             <Menu
+              key={option}
               id={option}
               anchorEl={anchorEl[option]}
               open={Boolean(anchorEl[option])}

--- a/src/components/PersistentDrawer.js
+++ b/src/components/PersistentDrawer.js
@@ -108,22 +108,10 @@ const styles = theme => ({
 });
 
 const optionKeyLabels = {
-  target: 'Allowable Target',
-  strict: 'Enforce code cleanliness standards',
-  minify: 'Reduce size of Compiled Python',
-  line_numbers: 'Show line numbers',
-  keep_lines: 'Keep line numbers',
-  no_tco: 'No TCO',
+  target: 'Allowable Targets',
 };
 
-const optionKeys = [
-  'target',
-  'strict',
-  'minify',
-  'line_numbers',
-  'keep_lines',
-  'no_tco',
-];
+const optionKeys = ['target'];
 
 const options = {
   target: [
@@ -136,20 +124,10 @@ const options = {
     'Python >= 3.5',
     'Python >= 3.6',
   ],
-  strict: ['Strict', 'False (Default)', 'True'],
-  minify: ['Minify', 'False (Default)', 'True'],
-  line_numbers: ['line_numbers', 'False (Default)', 'True'],
-  keep_lines: ['keep_lines', 'False (Default)', 'True'],
-  no_tco: ['no_tco', 'False (Default)', 'True'],
 };
 
 const values = {
   target: ['sys', '26', '27', '32', '33', '35', '36'],
-  strict: [false, true],
-  minify: [false, true],
-  line_numbers: [false, true],
-  keep_lines: [false, true],
-  no_tco: [false, true],
 };
 
 class PersistentDrawer extends React.Component {
@@ -158,27 +136,12 @@ class PersistentDrawer extends React.Component {
     anchor: 'left',
     anchorEl: {
       target: null,
-      strict: null,
-      minify: null,
-      line_numbers: null,
-      keep_lines: null,
-      no_tco: null,
     },
     selectedIndex: {
       target: 1,
-      strict: 1,
-      minify: 1,
-      line_numbers: 1,
-      keep_lines: 1,
-      no_tco: 1,
     },
     args: {
       target: 'sys',
-      strict: false,
-      minify: false,
-      line_numbers: false,
-      keep_lines: false,
-      no_tco: false,
     },
   };
 

--- a/src/components/PersistentDrawer.js
+++ b/src/components/PersistentDrawer.js
@@ -116,7 +116,7 @@ const optionKeys = ['target'];
 const options = {
   target: [
     'target',
-    'Current latest version (Default)',
+    'Latest version (Default)',
     'Python 2.6',
     'Python 2.7',
     'Python 3.2',

--- a/src/constants.js
+++ b/src/constants.js
@@ -16,3 +16,10 @@ export const editorHeaderTextColor = '#fff';
 
 export const outputHeaderColor = '#ebebeb';
 export const outputHeaderTextColor = '#000';
+
+export const headerTextStyle = {
+  fontSize: 16,
+  textTransform: 'uppercase',
+  fontWeight: 700,
+  letterSpacing: '0.08em',
+};

--- a/src/store/environment/actions.js
+++ b/src/store/environment/actions.js
@@ -16,11 +16,6 @@ export type Payload = {
 
 export type Args = {
   target: string,
-  strict: boolean,
-  minify: boolean,
-  line_numbers: boolean,
-  keep_lines: boolean,
-  no_tco: boolean,
 };
 
 export function runRequest(code: string, args: Args) {


### PR DESCRIPTION
Resolve #18 

![screen shot 2018-04-06 at 2 53 25 pm](https://user-images.githubusercontent.com/8051724/38445973-a3c363ee-39aa-11e8-8696-8c95e9fcb9cb.png)

- [x] remove extra options
- [x] frontend tests pass
- [x] manually testing works
- [x] remove redundancy of "Allowable Targets" as a label and a ghost option

Before:

![screen shot 2018-04-06 at 3 40 03 pm](https://user-images.githubusercontent.com/8051724/38447195-cda8867a-39b0-11e8-8f0c-ca4450535ba2.png)

After:

![screen shot 2018-04-06 at 3 24 51 pm](https://user-images.githubusercontent.com/8051724/38446777-bc744efe-39ae-11e8-8d92-2a80e9a18216.png)

- [ ] rename "Allowable Targets"? doesn't it make more sense to call it "target Python version" or something?