### PR TITLE
Responsive layout support

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -1,12 +1,13 @@
 // @flow
 
-import React, { Component } from 'react';
+import * as React from 'react';
 import AceEditor from 'react-ace';
 import type { EditorProps } from 'react-ace';
 import { withStyles } from 'material-ui/styles';
 
 import 'brace/theme/dracula';
 
+import EditorHeader from './EditorHeader';
 import PersistentDrawer from './PersistentDrawer';
 import errorMarker from '../utils/highlighter';
 import { aceStyleProps } from '../constants';
@@ -35,12 +36,22 @@ type Props = {
 
 type State = {
   code: string,
+  windowWidth: number,
 };
 
-class Editor extends Component<Props, State> {
+class Editor extends React.Component<Props, State> {
   state = {
     code: window.initialCode || '',
+    windowWidth: window.innerWidth,
   };
+
+  componentDidMount() {
+    window.addEventListener('resize', this.handleResize);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.handleResize);
+  }
 
   onEditorLoad = (editor: EditorProps) => {
     editor.renderer.setPadding(24);
@@ -64,28 +75,44 @@ class Editor extends Component<Props, State> {
       this.props.runRequest(this.state.code, this.props.args);
   };
 
-  render() {
-    const aceEditor = (
-      <AceEditor
-        name="code"
-        mode="text"
-        theme="dracula"
-        value={this.state.code}
-        onChange={this.handleChange}
-        onLoad={this.onEditorLoad}
-        {...aceStyleProps}
-        markers={this.getMarkers()}
-      />
-    );
+  handleResize = () => {
+    this.setState({ windowWidth: window.innerWidth });
+  };
 
+  renderAceEditor = () => (
+    <AceEditor
+      name="code"
+      mode="text"
+      theme="dracula"
+      value={this.state.code}
+      onChange={this.handleChange}
+      onLoad={this.onEditorLoad}
+      {...aceStyleProps}
+      markers={this.getMarkers()}
+    />
+  );
+
+  render() {
+    const { classes } = this.props;
     return (
-      <div className={styles.editor}>
-        <PersistentDrawer
-          aceEditor={aceEditor}
-          updateArgs={this.props.updateArgs}
-          handleClick={this.handleClick}
-          loading={this.props.loading}
-        />
+      <div className={classes.editor}>
+        {this.state.windowWidth < 600 ? (
+          <>
+            <EditorHeader
+              simple
+              handleClick={this.handleClick}
+              loading={this.props.loading}
+            />
+            {this.renderAceEditor()}
+          </>
+        ) : (
+          <PersistentDrawer
+            aceEditor={this.renderAceEditor()}
+            updateArgs={this.props.updateArgs}
+            handleClick={this.handleClick}
+            loading={this.props.loading}
+          />
+        )}
       </div>
     );
   }

--- a/src/components/EditorHeader.js
+++ b/src/components/EditorHeader.js
@@ -1,0 +1,161 @@
+// @flow
+
+import * as React from 'react';
+import classNames from 'classnames';
+import AppBar from 'material-ui/AppBar';
+import Toolbar from 'material-ui/Toolbar';
+import IconButton from 'material-ui/IconButton';
+import GearIcon from '@material-ui/icons/Settings';
+import Typography from 'material-ui/Typography';
+import SaveIcon from '@material-ui/icons/Save';
+import Button from 'material-ui/Button';
+import PlayArrow from '@material-ui/icons/PlayArrow';
+import ReactTooltip from 'react-tooltip';
+import { withStyles } from 'material-ui/styles';
+import type { Theme } from 'material-ui/styles';
+
+import { editorHeaderColor, headerTextStyle } from '../constants';
+
+const styles = (theme: Theme) => ({
+  appBar: {
+    backgroundColor: editorHeaderColor,
+    boxShadow: 'none',
+  },
+  toolbarRoot: {
+    minHeight: 48,
+    padding: '0 24px',
+  },
+  headerText: {
+    flex: 1,
+    ...headerTextStyle,
+  },
+  runButton: {
+    ...headerTextStyle,
+  },
+  menuButton: {
+    marginLeft: -12,
+    marginRight: 20,
+  },
+  hide: {
+    display: 'none',
+  },
+  gearIcon: {
+    fontSize: 21,
+  },
+  downloadButton: {
+    margin: 0,
+    ...headerTextStyle,
+  },
+  downloadIcon: {
+    fontSize: 20,
+  },
+  tooltip: {
+    fontFamily: 'Roboto',
+    fontSize: 14,
+    padding: theme.spacing.unit,
+  },
+});
+
+type Props = {
+  simple: boolean,
+  appBarClassNames?: string,
+  open?: boolean,
+  handleDrawerOpen?: () => void,
+  coconutCode?: string,
+  handleClick: () => void,
+  loading: boolean,
+  classes: $Call<typeof styles>,
+};
+
+class EditorHeader extends React.Component<Props> {
+  handleDownloadClick = code => {
+    const element = document.createElement('a');
+    const file = new Blob([code], { type: 'text/plain' });
+    element.href = URL.createObjectURL(file);
+    element.download = 'coconut.coco';
+    if (document.body) document.body.appendChild(element);
+    element.click();
+
+    // Timeout to prevent the element being removed too soon in some browsers like Firefox
+    setTimeout(() => {
+      if (document.body) document.body.removeChild(element);
+      window.URL.revokeObjectURL(element.href);
+    }, 100);
+  };
+
+  render() {
+    const { simple, open, classes } = this.props;
+    return (
+      <AppBar
+        className={simple ? classes.appBar : this.props.appBarClassNames}
+        position="static" // TODO -> editor.js
+      >
+        <Toolbar
+          classes={{ root: classes.toolbarRoot }}
+          disableGutters={!simple && !open}
+        >
+          {!simple && (
+            <>
+              <ReactTooltip
+                id="settings"
+                className={classes.tooltip}
+                place="right"
+                type="dark"
+                effect="solid"
+              />
+              <IconButton
+                data-tip="Settings"
+                data-for="settings"
+                color="inherit"
+                aria-label="open drawer"
+                onClick={this.props.handleDrawerOpen}
+                className={classNames(classes.menuButton, open && classes.hide)}
+              >
+                <GearIcon className={classes.gearIcon} />
+              </IconButton>
+            </>
+          )}
+          <Typography
+            variant="title"
+            color="inherit"
+            className={classes.headerText}
+            noWrap
+          >
+            Coconut Editor
+          </Typography>
+          {!simple && (
+            <>
+              <ReactTooltip
+                id="download"
+                className={classes.tooltip}
+                place="bottom"
+                type="dark"
+                effect="solid"
+              />
+              <IconButton
+                data-tip="Download"
+                data-for="download"
+                color="inherit"
+                className={classes.downloadButton}
+                onClick={() => this.handleDownloadClick(this.props.coconutCode)}
+              >
+                <SaveIcon className={classes.downloadIcon} />
+              </IconButton>
+            </>
+          )}
+          <Button
+            color="inherit"
+            className={classes.runButton}
+            onClick={this.props.handleClick}
+            disabled={this.props.loading}
+          >
+            Run
+            <PlayArrow />
+          </Button>
+        </Toolbar>
+      </AppBar>
+    );
+  }
+}
+
+export default withStyles(styles)(EditorHeader);

--- a/src/components/EditorHeader.js
+++ b/src/components/EditorHeader.js
@@ -40,11 +40,7 @@ const styles = (theme: Theme) => ({
     display: 'none',
   },
   gearIcon: {
-    fontSize: 21,
-  },
-  downloadButton: {
-    margin: 0,
-    ...headerTextStyle,
+    fontSize: 20,
   },
   downloadIcon: {
     fontSize: 20,
@@ -86,10 +82,7 @@ class EditorHeader extends React.Component<Props> {
   render() {
     const { simple, open, classes } = this.props;
     return (
-      <AppBar
-        className={simple ? classes.appBar : this.props.appBarClassNames}
-        position="static" // TODO -> editor.js
-      >
+      <AppBar className={simple ? classes.appBar : this.props.appBarClassNames}>
         <Toolbar
           classes={{ root: classes.toolbarRoot }}
           disableGutters={!simple && !open}

--- a/src/components/EditorHeader.js
+++ b/src/components/EditorHeader.js
@@ -129,7 +129,6 @@ class EditorHeader extends React.Component<Props> {
                 data-tip="Download"
                 data-for="download"
                 color="inherit"
-                className={classes.downloadButton}
                 onClick={() => this.handleDownloadClick(this.props.coconutCode)}
               >
                 <SaveIcon className={classes.downloadIcon} />

--- a/src/components/PersistentDrawer.js
+++ b/src/components/PersistentDrawer.js
@@ -65,8 +65,6 @@ const styles = (theme: Theme) => ({
     flexGrow: 1,
     backgroundColor: theme.palette.background.default,
     padding: 0,
-    marginTop: '48px',
-    height: `calc(100% - 48)px`,
     transition: theme.transitions.create('margin', {
       easing: theme.transitions.easing.sharp,
       duration: theme.transitions.duration.leavingScreen,

--- a/src/components/PersistentDrawer.js
+++ b/src/components/PersistentDrawer.js
@@ -3,24 +3,17 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import { withStyles } from 'material-ui/styles';
-import Button from 'material-ui/Button';
 import Drawer from 'material-ui/Drawer';
-import AppBar from 'material-ui/AppBar';
-import Toolbar from 'material-ui/Toolbar';
 import List, { ListItem, ListItemText } from 'material-ui/List';
 import Menu, { MenuItem } from 'material-ui/Menu';
-import Typography from 'material-ui/Typography';
 import Divider from 'material-ui/Divider';
 import IconButton from 'material-ui/IconButton';
-import GearIcon from '@material-ui/icons/Settings';
 import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
-import PlayArrow from '@material-ui/icons/PlayArrow';
-import SaveIcon from '@material-ui/icons/Save';
 import AceEditor from 'react-ace';
-import ReactTooltip from 'react-tooltip';
 import type { Theme } from 'material-ui/styles';
 
-import { editorHeaderColor, headerTextStyle } from '../constants';
+import EditorHeader from './EditorHeader';
+import { editorHeaderColor } from '../constants';
 import type { Args } from '../store/environment/actions';
 
 const drawerWidth = 240;
@@ -28,10 +21,6 @@ const drawerWidth = 240;
 const styles = (theme: Theme) => ({
   root: {
     flexGrow: 1,
-  },
-  headerText: {
-    flex: 1,
-    ...headerTextStyle,
   },
   appFrame: {
     zIndex: 1,
@@ -59,13 +48,6 @@ const styles = (theme: Theme) => ({
   },
   'appBarShift-left': {
     marginLeft: drawerWidth,
-  },
-  menuButton: {
-    marginLeft: -12,
-    marginRight: 20,
-  },
-  hide: {
-    display: 'none',
   },
   drawerPaper: {
     position: 'relative',
@@ -102,28 +84,6 @@ const styles = (theme: Theme) => ({
   },
   'contentShift-left': {
     marginLeft: 0,
-  },
-  runButton: {
-    ...headerTextStyle,
-  },
-  toolbarRoot: {
-    minHeight: 48,
-    padding: '0 24px',
-  },
-  gearIcon: {
-    fontSize: 21,
-  },
-  downloadButton: {
-    margin: 0,
-    ...headerTextStyle,
-  },
-  downloadIcon: {
-    fontSize: 20,
-  },
-  tooltip: {
-    fontFamily: 'Roboto',
-    fontSize: 14,
-    padding: theme.spacing.unit,
   },
 });
 
@@ -313,68 +273,18 @@ class PersistentDrawer extends React.Component<Props, State> {
     return (
       <div className={classes.root}>
         <div className={classes.appFrame}>
-          <AppBar
-            className={classNames(classes.appBar, {
+          <EditorHeader
+            simple={false}
+            appBarClassNames={classNames(classes.appBar, {
               [classes.appBarShift]: open,
               [classes[`appBarShift-${anchor}`]]: open,
             })}
-          >
-            <Toolbar
-              disableGutters={!open}
-              classes={{ root: classes.toolbarRoot }}
-            >
-              <ReactTooltip
-                id="settings"
-                className={classes.tooltip}
-                place="right"
-                type="dark"
-                effect="solid"
-              />
-              <IconButton
-                data-tip="Settings"
-                data-for="settings"
-                color="inherit"
-                aria-label="open drawer"
-                onClick={this.handleDrawerOpen}
-                className={classNames(classes.menuButton, open && classes.hide)}
-              >
-                <GearIcon className={classes.gearIcon} />
-              </IconButton>
-              <Typography
-                variant="title"
-                color="inherit"
-                className={classes.headerText}
-                noWrap
-              >
-                Coconut Editor
-              </Typography>
-              <ReactTooltip
-                id="download"
-                className={classes.tooltip}
-                place="bottom"
-                type="dark"
-                effect="solid"
-              />
-              <IconButton
-                data-tip="Download"
-                data-for="download"
-                color="inherit"
-                className={classes.downloadButton}
-                onClick={() => this.handleDownloadClick(coconutCode)}
-              >
-                <SaveIcon className={classes.downloadIcon} />
-              </IconButton>
-              <Button
-                color="inherit"
-                className={classes.runButton}
-                onClick={this.props.handleClick}
-                disabled={this.props.loading}
-              >
-                Run
-                <PlayArrow />
-              </Button>
-            </Toolbar>
-          </AppBar>
+            open={open}
+            handleDrawerOpen={this.handleDrawerOpen}
+            coconutCode={coconutCode}
+            handleClick={this.props.handleClick}
+            loading={this.props.loading}
+          />
           {before}
           <main
             className={classNames(

--- a/src/components/__tests__/EditorHeader.test.js
+++ b/src/components/__tests__/EditorHeader.test.js
@@ -45,6 +45,13 @@ it('renders zero <IconButton /> components', () => {
   expect(wrapper.find(IconButton)).toHaveLength(0);
 });
 
+it('renders two <IconButton /> components (!simple)', () => {
+  const wrapper = shallow(
+    <EditorHeader simple={false} handleClick={handleClick} loading={false} />
+  ).dive();
+  expect(wrapper.find(IconButton)).toHaveLength(2);
+});
+
 it('renders active run button while not loading', () => {
   const wrapper = shallow(
     <EditorHeader simple handleClick={handleClick} loading={false} />

--- a/src/components/__tests__/EditorHeader.test.js
+++ b/src/components/__tests__/EditorHeader.test.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import AppBar from 'material-ui/AppBar';
+import Typography from 'material-ui/Typography';
+import Button from 'material-ui/Button';
+import IconButton from 'material-ui/IconButton';
+
+import EditorHeader from '../EditorHeader';
+
+let handleClick;
+
+beforeEach(() => {
+  handleClick = jest.fn();
+});
+
+it('renders without crashing', () => {
+  shallow(<EditorHeader simple handleClick={handleClick} loading={false} />);
+});
+
+it('renders one <AppBar /> component', () => {
+  const wrapper = shallow(
+    <EditorHeader simple handleClick={handleClick} loading={false} />
+  ).dive();
+  expect(wrapper.find(AppBar)).toHaveLength(1);
+});
+
+it('renders one <Typography /> component', () => {
+  const wrapper = shallow(
+    <EditorHeader simple handleClick={handleClick} loading={false} />
+  ).dive();
+  expect(wrapper.find(Typography)).toHaveLength(1);
+});
+
+it('renders one <Button /> component', () => {
+  const wrapper = shallow(
+    <EditorHeader simple handleClick={handleClick} loading={false} />
+  ).dive();
+  expect(wrapper.find(Button)).toHaveLength(1);
+});
+
+it('renders zero <IconButton /> components', () => {
+  const wrapper = shallow(
+    <EditorHeader simple handleClick={handleClick} loading={false} />
+  ).dive();
+  expect(wrapper.find(IconButton)).toHaveLength(0);
+});
+
+it('renders active run button while not loading', () => {
+  const wrapper = shallow(
+    <EditorHeader simple handleClick={handleClick} loading={false} />
+  ).dive();
+  expect(wrapper.find(Button).props().disabled).toEqual(false);
+});
+
+it('renders disabled run button while loading', () => {
+  const wrapper = shallow(
+    <EditorHeader simple handleClick={handleClick} loading />
+  ).dive();
+  expect(wrapper.find(Button).props().disabled).toEqual(true);
+});
+
+it('simulates click events', () => {
+  const wrapper = shallow(
+    <EditorHeader simple handleClick={handleClick} loading={false} />
+  ).dive();
+  wrapper.find(Button).simulate('click');
+  expect(handleClick.mock.calls).toHaveLength(1);
+});

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,7 +6,8 @@ export const aceStyleProps = {
   scrollMargin: [24, 24, 0, 0],
   setOptions: { indentedSoftWrap: false, displayIndentGuides: false },
   width: '100%',
-  height: 'calc(100%)', // TODO: fix calculation
+  height: 'calc(100% - 48px)',
+  style: { marginTop: 48 },
   editorProps: { $blockScrolling: Infinity },
   fontSize: 14,
 };

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -8,7 +8,6 @@ import OutputContainer from './OutputContainer';
 
 const styles = () => ({
   container: {
-    overflow: 'hidden',
     height: '100vh',
     fontFamily: 'Roboto',
     display: 'grid',


### PR DESCRIPTION
The addition of the drawer component broke our responsive layout on small screens (width < 600). Fix by only showing the drawer on larger screens.

Before:
<img width="594" alt="screen shot 2018-04-13 at 5 00 39 pm" src="https://user-images.githubusercontent.com/8571671/38761999-480db1fc-3f3c-11e8-987c-48c084226735.png">

After:
<img width="594" alt="screen shot 2018-04-13 at 5 00 59 pm" src="https://user-images.githubusercontent.com/8571671/38762003-4e0c5ad6-3f3c-11e8-879e-4ec91a54d8eb.png">
